### PR TITLE
Update launcher paths to OPENTUNA directory

### DIFF
--- a/launcher-boot/main.c
+++ b/launcher-boot/main.c
@@ -100,11 +100,11 @@ int main(int argc, char *argv[])
 
 	InitPS2();
 
-	if (file_exists("mc0:/BOOT/BOOT.ELF"))
-		LoadElf("mc0:/BOOT/BOOT.ELF", "mc0:/BOOT/");
+       if (file_exists("mc0:/OPENTUNA/BOOT.ELF"))
+               LoadElf("mc0:/OPENTUNA/BOOT.ELF", "mc0:/OPENTUNA/");
 
-	if (file_exists("mc1:/BOOT/BOOT.ELF"))
-		LoadElf("mc1:/BOOT/BOOT.ELF", "mc1:/BOOT/");
+       if (file_exists("mc1:/OPENTUNA/BOOT.ELF"))
+               LoadElf("mc1:/OPENTUNA/BOOT.ELF", "mc1:/OPENTUNA/");
 
 	__asm__ __volatile__(
 		"	li $3, 0x04;"

--- a/launcher-keys/main.c
+++ b/launcher-keys/main.c
@@ -153,34 +153,22 @@ int main(int argc, char *argv[])
 		padEnd();
 	}
 
-	if (lastKey & PAD_CIRCLE)
-	{
-		if (file_exists("mc0:/BOOT/BOOT.ELF"))
-			LoadElf("mc0:/BOOT/BOOT.ELF", "mc0:/BOOT/");
+       if (lastKey & PAD_CIRCLE)
+       {
+              if (file_exists("mc0:/OPENTUNA/BOOT.ELF"))
+                      LoadElf("mc0:/OPENTUNA/BOOT.ELF", "mc0:/OPENTUNA/");
 
-		if (file_exists("mc1:/BOOT/BOOT.ELF"))
-			LoadElf("mc1:/BOOT/BOOT.ELF", "mc1:/BOOT/");
+              if (file_exists("mc1:/OPENTUNA/BOOT.ELF"))
+                      LoadElf("mc1:/OPENTUNA/BOOT.ELF", "mc1:/OPENTUNA/");
+       }
+       else
+       {
+              if (file_exists("mc0:/OPENTUNA/BOOT.ELF"))
+                      LoadElf("mc0:/OPENTUNA/BOOT.ELF", "mc0:/OPENTUNA/");
 
-		if (file_exists("mc0:/BOOT/FMCBD.ELF"))
-			LoadElf("mc0:/BOOT/FMCBD.ELF", "mc0:/BOOT/");
-
-		if (file_exists("mc1:/BOOT/FMCBD.ELF"))
-			LoadElf("mc1:/BOOT/FMCBD.ELF", "mc0:/BOOT/");
-	}
-	else
-	{
-		if (file_exists("mc0:/BOOT/FMCBD.ELF"))
-			LoadElf("mc0:/BOOT/FMCBD.ELF", "mc0:/BOOT/");
-
-		if (file_exists("mc1:/BOOT/FMCBD.ELF"))
-			LoadElf("mc1:/BOOT/FMCBD.ELF", "mc0:/BOOT/");
-
-		if (file_exists("mc0:/BOOT/BOOT.ELF"))
-			LoadElf("mc0:/BOOT/BOOT.ELF", "mc0:/BOOT/");
-
-		if (file_exists("mc1:/BOOT/BOOT.ELF"))
-			LoadElf("mc1:/BOOT/BOOT.ELF", "mc1:/BOOT/");
-	}
+              if (file_exists("mc1:/OPENTUNA/BOOT.ELF"))
+                      LoadElf("mc1:/OPENTUNA/BOOT.ELF", "mc1:/OPENTUNA/");
+       }
 
 	__asm__ __volatile__(
 		"	li $3, 0x04;"


### PR DESCRIPTION
## Summary
- Adjust launcher-boot to load from mcX:/OPENTUNA/ instead of BOOT
- Simplify launcher-keys to always load OPENTUNA/BOOT.ELF

## Testing
- `make -C launcher-boot` *(fails: `/samples/Makefile.eeglobal: No such file or directory`)*
- `make -C launcher-keys` *(fails: `/samples/Makefile.eeglobal: No such file or directory`)*
- `make -C exploit` *(fails: `ee-gcc: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8226b79483219a2dc29383dcbc7e