### PR TITLE
Run Docker build container as non-root user

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       run: docker build . --tag opentuna-build:latest
     - name: Run the build in the container
       run: |
-        docker run --rm -v "${{ github.workspace }}":/app -w /app \
+        docker run --rm --user $(id -u):$(id -g) -v "${{ github.workspace }}":/app -w /app \
         -e "WINEPREFIX=/tmp/.wine" \
         opentuna-build:latest \
         make -C exploit


### PR DESCRIPTION
## Summary
- run Docker container as current user in build workflow

## Testing
- `make -C exploit` *(fails: mips64r5900el-ps2-elf-gcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68acc44f5d2c8321828db98f64d5b6b9