### PR TITLE
launcher-boot: run ps2_packer under xvfb

### DIFF
--- a/launcher-boot/Makefile
+++ b/launcher-boot/Makefile
@@ -33,7 +33,7 @@ $(EE_BIN_PACKED): $(EE_BIN_STRIPPED)
 ifdef OS
 	../ps2_packer/ps2_packer.exe -v $< $@
 else
-	wine ../ps2_packer/ps2_packer.exe -v $< $@
+	xvfb-run wine ../ps2_packer/ps2_packer.exe -v $< $@
 endif
 	
 


### PR DESCRIPTION
## Summary
- use `xvfb-run wine` for ps2_packer in launcher-boot
- align launcher-boot Makefile logic with launcher-keys

## Testing
- `make -C launcher-boot` *(fails: /samples/Makefile.eeglobal: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68acc4d08e908321a15ed1118ab42938