### PR TITLE
Add 32-bit Wine dependencies to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM ps2dev/ps2dev:latest
 
-RUN apk add --no-cache make wine xvfb gcc libc-dev xvfb-run vulkan-dev
+RUN apk add --no-cache make wine xvfb gcc libc-dev xvfb-run vulkan-dev lib32gcc lib32stdc++


### PR DESCRIPTION
## Summary
- install lib32gcc and lib32stdc++ in Docker image for 32-bit Wine compatibility

## Testing
- `docker build -t opentuna .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68acc5a599908321aef24a6fedcff97e