### PR TITLE
Add extra 32-bit Wine dependencies to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM ps2dev/ps2dev:latest
 
-RUN apk add --no-cache make wine xvfb gcc libc-dev xvfb-run vulkan-dev lib32gcc lib32stdc++
+RUN apk add --no-cache make wine xvfb gcc libc-dev xvfb-run vulkan-dev lib32gcc lib32stdc++ lib32zlib lib32ncurses


### PR DESCRIPTION
## Summary
- extend apk setup to pull in more 32-bit Wine libraries

## Testing
- `docker build -t opentuna-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68acc6f00e7883218c0fb708f853ccc4