### PR TITLE
Fix Vulkan and 32-bit package names in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM ps2dev/ps2dev:latest
 
-RUN apk add --no-cache make wine xvfb gcc libc-dev xvfb-run vulkan-dev lib32gcc lib32stdc++ lib32zlib lib32ncurses
+RUN apk add --no-cache make wine xvfb gcc libc-dev xvfb-run vulkan-loader-dev libgcc libstdc++ zlib-dev ncurses-libs


### PR DESCRIPTION
## Summary
- use `vulkan-loader-dev` instead of non-existent `vulkan-dev`
- switch lib32 packages to Alpine names

## Testing
- `docker build -t ps2dev-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68acc9c1bf6c832189f427a47bf8322d