### PR TITLE
Use xvfb-run for ps2_packer in launcher-boot

### DIFF
--- a/launcher-boot/Makefile
+++ b/launcher-boot/Makefile
@@ -33,7 +33,7 @@ $(EE_BIN_PACKED): $(EE_BIN_STRIPPED)
 ifdef OS
 	../ps2_packer/ps2_packer.exe -v $< $@
 else
-	wine ../ps2_packer/ps2_packer.exe -v $< $@
+	xvfb-run wine ../ps2_packer/ps2_packer.exe -v $< $@
 endif
 	
 


### PR DESCRIPTION
## Summary
- wrap ps2_packer invocation with `xvfb-run wine` in `launcher-boot` to match `launcher-keys`

## Testing
- `make -C launcher-boot clean` *(fails: No rule to make target '/samples/Makefile.eeglobal')*
- `make -C launcher-boot` *(fails: No rule to make target '/samples/Makefile.eeglobal')*


------
https://chatgpt.com/codex/tasks/task_e_68acce755b3c8321a9addf9c9dbda87c