### PR TITLE
Add Wine dependencies to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ps2dev/ps2dev:latest
 
-RUN apk add --no-cache git
+RUN apk add --no-cache git wine lib32gcc lib32stdc++
 
 RUN git clone https://github.com/ps2dev/ps2sdk.git /tmp/ps2sdk
 


### PR DESCRIPTION
## Summary
- add Wine 32-bit dependency packages to `apk add`

## Testing
- `docker build -t opentuna-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68accf9c89e48321a2631b3d6ac85d18