### PR TITLE
Fix workflow and switch to bin2c payload embedding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,3 @@ jobs:
           -e HOME=/app -e WINEPREFIX=/app/.wine \
           opentuna-build:latest \
           bash -lc "mkdir -p \$WINEPREFIX && make -C exploit"
-    - uses: actions/checkout@v4
-    - name: Build the Docker image for exploration
-      run: docker build . --tag opentuna-build:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
 FROM ps2dev/ps2dev:latest
 
-RUN apk add --no-cache git wine lib32gcc lib32stdc++
+RUN apk add --no-cache \
+    make \
+    wine \
+    xvfb \
+    gcc \
+    libc-dev \
+    xvfb-run \
+    vulkan-loader-dev \
+    libgcc \
+    libstdc++ \
+    zlib-dev \
+    ncurses-libs
 
-RUN git clone https://github.com/ps2dev/ps2sdk.git /tmp/ps2sdk
-
-RUN cat /tmp/ps2sdk/Makefile.eeglobal

--- a/exploit/Makefile
+++ b/exploit/Makefile
@@ -29,7 +29,8 @@ payload_elf.o: payload_elf.c
 
 payload_elf.c:
 	$(MAKE) -C ../$(PAYLOAD)/
-	bin2c ../$(PAYLOAD)/payload-packed.elf payload_elf.c payload_elf
+	$(MAKE) -C ../tools/bin2c
+	../tools/bin2c/bin2c ../$(PAYLOAD)/payload-packed.elf payload_elf.c payload_elf
 
 clean:
 	$(MAKE) -C ../$(PAYLOAD)/ clean

--- a/tools/bin2c/Makefile
+++ b/tools/bin2c/Makefile
@@ -1,0 +1,10 @@
+CC ?= gcc
+CFLAGS ?= -O2 -Wall
+
+all: bin2c
+
+bin2c: bin2c.c
+	$(CC) $(CFLAGS) -o $@ $<
+
+clean:
+	rm -f bin2c

--- a/tools/bin2c/bin2c.c
+++ b/tools/bin2c/bin2c.c
@@ -1,0 +1,36 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+    if (argc < 4) {
+        fprintf(stderr, "Usage: %s input output name\n", argv[0]);
+        return 1;
+    }
+    const char *in_path = argv[1];
+    const char *out_path = argv[2];
+    const char *sym = argv[3];
+    FILE *in = fopen(in_path, "rb");
+    if (!in) {
+        perror("fopen input");
+        return 1;
+    }
+    FILE *out = fopen(out_path, "w");
+    if (!out) {
+        perror("fopen output");
+        fclose(in);
+        return 1;
+    }
+    unsigned char byte;
+    size_t count = 0;
+    fprintf(out, "unsigned char %s[] = {", sym);
+    while (fread(&byte, 1, 1, in) == 1) {
+        if (count % 12 == 0)
+            fprintf(out, "\n ");
+        fprintf(out, "0x%02x,", byte);
+        count++;
+    }
+    fprintf(out, "\n};\nunsigned int size_%s = %zu;\n", sym, count);
+    fclose(in);
+    fclose(out);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- run build container as non-root and set WINEPREFIX inside workspace
- add required Wine and build dependencies to Docker image
- embed packed payload using new bin2c tool

## Testing
- `docker build . --tag opentuna-build:latest` *(fails: command not found)*
- `make -C tools/bin2c`
- `make -C exploit` *(fails: No rule to make target 'payload.elf', needed by 'payload-stripped.elf')*


------
https://chatgpt.com/codex/tasks/task_e_68acc356d3e483219bf4d5b037cbdb9a