### PR TITLE
Replace custom u-types with stdint fixed-width types

### DIFF
--- a/exploit/main.c
+++ b/exploit/main.c
@@ -1,12 +1,13 @@
 #include <kernel.h>
 #include <string.h>
+#include <stdint.h>
 
 
 // ELF-loading stuff
 #define ELF_MAGIC 0x464c457f
 #define ELF_PT_LOAD 1
 
-extern u8 payload_elf[];
+extern uint8_t payload_elf[];
 extern int size_payload_elf;
 
 
@@ -15,32 +16,32 @@ extern int size_payload_elf;
 //------------------------------
 typedef struct
 {
-	u8 ident[16]; // struct definition for ELF object header
-	u16 type;
-	u16 machine;
-	u32 version;
-	u32 entry;
-	u32 phoff;
-	u32 shoff;
-	u32 flags;
-	u16 ehsize;
-	u16 phentsize;
-	u16 phnum;
-	u16 shentsize;
-	u16 shnum;
-	u16 shstrndx;
+        uint8_t ident[16]; // struct definition for ELF object header
+        uint16_t type;
+        uint16_t machine;
+        uint32_t version;
+        uint32_t entry;
+        uint32_t phoff;
+        uint32_t shoff;
+        uint32_t flags;
+        uint16_t ehsize;
+        uint16_t phentsize;
+        uint16_t phnum;
+        uint16_t shentsize;
+        uint16_t shnum;
+        uint16_t shstrndx;
 } elf_header_t;
 //------------------------------
 typedef struct
 {
-	u32 type; // struct definition for ELF program section header
-	u32 offset;
-	void *vaddr;
-	u32 paddr;
-	u32 filesz;
-	u32 memsz;
-	u32 flags;
-	u32 align;
+        uint32_t type; // struct definition for ELF program section header
+        uint32_t offset;
+        void *vaddr;
+        uint32_t paddr;
+        uint32_t filesz;
+        uint32_t memsz;
+        uint32_t flags;
+        uint32_t align;
 } elf_pheader_t;
 
 
@@ -52,7 +53,7 @@ typedef struct
 
 static inline void _start()
 {
-	u8 *boot_elf;
+        uint8_t *boot_elf;
 	elf_header_t *eh;
 	elf_pheader_t *eph;
 	void *pdata;
@@ -64,9 +65,9 @@ static inline void _start()
 
 	
 	/* Pointer to embedded payload  */
-	boot_elf = (u8 *)payload_elf;
+        boot_elf = (uint8_t *)payload_elf;
 	eh = (elf_header_t *)boot_elf;
-	if (_lw((u32)&eh->ident) != ELF_MAGIC)
+        if (_lw((uint32_t)&eh->ident) != ELF_MAGIC)
 		asm volatile("break\n");
 
 	eph = (elf_pheader_t *)(boot_elf + eh->phoff);

--- a/launcher-keys/main.c
+++ b/launcher-keys/main.c
@@ -31,12 +31,12 @@ int  setupPad(void);
 #define DELAY 0
 
 int VMode = NTSC;
-extern u32 new_pad;
+extern uint32_t new_pad;
 
 char romver_region_char[1];
 char ROMVersionNumStr[5];
-u8 romver[16];
-u32 bios_version = 0;
+uint8_t romver[16];
+uint32_t bios_version = 0;
 
 static void wipeUserMem(void)
 {
@@ -117,7 +117,7 @@ int file_exists(char filepath[])
 int main(int argc, char *argv[])
 {
 
-	u32 lastKey = 0;
+        uint32_t lastKey = 0;
 	int isEarlyJap = 0;
 
 	wipeUserMem();

--- a/launcher-keys/pad.c
+++ b/launcher-keys/pad.c
@@ -33,9 +33,9 @@
  ---------------------------------------------------------------------------
 */
 
-#include <tamtypes.h>
 #include <kernel.h>
 #include <libpad.h>
+#include <stdint.h>
 
 // ntsc_pal
 #define NTSC			2
@@ -44,7 +44,7 @@
 // For video Mode
 extern int VMode;
 
-u32 new_pad;
+uint32_t new_pad;
 
 int  readPad(void);
 void waitAnyPadReady(void);
@@ -54,11 +54,11 @@ int  setupPad(void);
 
 static char padBuf_t[2][256] __attribute__((aligned(64)));
 struct padButtonStatus buttons_t[2];
-u32 padtype_t[2];
-u32 paddata, paddata_t[2];
-u32 old_pad = 0, old_pad_t[2] = {0, 0};
-u32 new_pad_t[2];
-u32 joy_value = 0;
+uint32_t padtype_t[2];
+uint32_t paddata, paddata_t[2];
+uint32_t old_pad = 0, old_pad_t[2] = {0, 0};
+uint32_t new_pad_t[2];
+uint32_t joy_value = 0;
 static int test_joy = 0;
 
 #define PAD_R3_V0 0x010000


### PR DESCRIPTION
## Summary
- replace legacy `u8/u16/u32` aliases with `uint8_t` et al.
- include `<stdint.h>` where needed for consistent standard types

## Testing
- `make -C launcher-keys` *(fails: /samples/Makefile.eeglobal: No such file or directory)*
- `make -C exploit` *(fails: /samples/Makefile.eeglobal: No such file or directory)*
- `make -C launcher-boot` *(fails: /samples/Makefile.eeglobal: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68acdd91e4608321ac304de93bc78c59