### PR TITLE
Adjust PS2SDK include order in exploit build

### DIFF
--- a/exploit/Makefile
+++ b/exploit/Makefile
@@ -1,6 +1,3 @@
-include $(PS2SDK)/samples/Makefile.pref
-include $(PS2SDK)/samples/Makefile.eeglobal
-
 #OpenTuna exploit Makefile
 #alexparrado (2020)
 
@@ -10,7 +7,6 @@ PAYLOAD ?= launcher-keys
 
 #OpenTuna load address
 LOADADDR  ?= 0x20c020c0
-
 
 
 EE_TARGET=payload
@@ -42,3 +38,6 @@ $(EE_BIN_STRIPPED): $(EE_BIN)
 #Rule for raw binary to embed into icon.icn
 $(EE_BIN_RAW): $(EE_BIN_STRIPPED)
 	$(EE_OBJCOPY) -O binary -v $< $@
+
+include $(PS2SDK)/samples/Makefile.pref
+include $(PS2SDK)/samples/Makefile.eeglobal


### PR DESCRIPTION
## Summary
- move PS2SDK sample makefile includes after exploit build variables and rules

## Testing
- `make -C exploit` *(fails: `/samples/Makefile.eeglobal: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68acdf990fa08321bef97c91f61e0105