### PR TITLE
Use tab for ps2-packer command in launcher keys

### DIFF
--- a/launcher-keys/Makefile
+++ b/launcher-keys/Makefile
@@ -30,7 +30,7 @@ $(EE_BIN_STRIPPED): $(EE_BIN)
 
 	
 $(EE_BIN_PACKED): $(EE_BIN_STRIPPED)
-       ps2-packer -v $< $@
+	ps2-packer -v $< $@
 	
 
 


### PR DESCRIPTION
## Summary
- Fix `ps2-packer` command indent in `launcher-keys/Makefile` to use a tab so `make` executes properly

## Testing
- `PS2SDK=../fake_ps2sdk GSKIT=../fake_ps2sdk PATH="../tools/ps2-packer:$PATH" make` *(fails: Unable to open stub file ps2-packer/stub/lzma-1d00-stub)*

------
https://chatgpt.com/codex/tasks/task_e_68ace176d42883219a3a00e0ad3cae70