### PR TITLE
Declare payload_elf.c dependencies for incremental builds

### DIFF
--- a/exploit/Makefile
+++ b/exploit/Makefile
@@ -23,10 +23,10 @@ all:
 payload_elf.o: payload_elf.c
 	$(EE_CC) $(EE_CFLAGS) -c $< -o $@
 
-payload_elf.c:
-	$(MAKE) -C ../$(PAYLOAD)/
+payload_elf.c: ../$(PAYLOAD)/payload-packed.elf ../tools/bin2c/bin2c
+	$(MAKE) -C ../$(PAYLOAD)
 	$(MAKE) -C ../tools/bin2c
-	../tools/bin2c/bin2c ../$(PAYLOAD)/payload-packed.elf payload_elf.c payload_elf
+	../tools/bin2c/bin2c $< $@ payload_elf
 
 clean:
 	$(MAKE) -C ../$(PAYLOAD)/ clean


### PR DESCRIPTION
## Summary
- Ensure `payload_elf.c` depends on the packed payload and `bin2c`
- Rebuild `payload_elf.c` only when its inputs change

## Testing
- `make payload_elf.c PAYLOAD=dummy PS2SDK=/tmp/ps2sdk`
- `make payload_elf.c PAYLOAD=dummy PS2SDK=/tmp/ps2sdk`

------
https://chatgpt.com/codex/tasks/task_e_68ace2864a5083218ef846d03d58c0c9