### PR TITLE
Run build container as root

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
         run: docker build . --tag opentuna-build:latest
       - name: Run the build in the container
         run: |
-          docker run --rm --user $(id -u):$(id -g) -v "${{ github.workspace }}":/app -w /app \
+          docker run --rm -v "${{ github.workspace }}":/app -w /app \
           -e HOME=/app \
           opentuna-build:latest \
           bash -lc "make -C exploit"


### PR DESCRIPTION
## Summary
- run Docker container as root in build workflow so PS2DEV toolchain is on PATH

## Testing
- ⚠️ `docker build . --tag opentuna-build:latest` *(failed: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68ace4ae81548321a377c0cbf7351fae