### PR TITLE
Append -Os to EE_CFLAGS

### DIFF
--- a/exploit/Makefile
+++ b/exploit/Makefile
@@ -15,7 +15,7 @@ EE_BIN_RAW = $(EE_TARGET).bin
 EE_BIN_STRIPPED = $(EE_TARGET)-stripped.elf
 EE_OBJS = main.o   payload_elf.o
 EE_LDFLAGS +=  -nostartfiles  -Wl,-Ttext -Wl,$(LOADADDR)   -Wl,--gc-sections
-EE_CFLAGS=-Os
+EE_CFLAGS += -Os
 
 all:
 	$(MAKE) $(EE_BIN_RAW)

--- a/launcher-boot/Makefile
+++ b/launcher-boot/Makefile
@@ -11,7 +11,7 @@ EE_OBJS = main.o
 EE_LDFLAGS +=   -Wl,--gc-sections  -Wl,-Ttext -Wl,$(LOADADDR)  -Wl,--defsym -Wl,_stack_size=$(STACKSIZE) -Wl,--defsym -Wl,_stack=$(STACKADDR)
 EE_LIBS = -lc -lpatches 
 EE_INCS= -I$(GSKIT)/include -I$(PS2SDK)/ports/include
-EE_CFLAGS=-Os 
+EE_CFLAGS += -Os
 
 
 

--- a/launcher-keys/Makefile
+++ b/launcher-keys/Makefile
@@ -11,7 +11,7 @@ EE_OBJS = main.o         pad.o
 EE_LDFLAGS +=   -Wl,--gc-sections  -Wl,-Ttext -Wl,$(LOADADDR)  -Wl,--defsym -Wl,_stack_size=$(STACKSIZE) -Wl,--defsym -Wl,_stack=$(STACKADDR)
 EE_LIBS = -lc -lpatches -lpad 
 EE_INCS= -I$(GSKIT)/include -I$(PS2SDK)/ports/include
-EE_CFLAGS=-Os 
+EE_CFLAGS += -Os
 
 
 


### PR DESCRIPTION
## Summary
- keep PS2SDK flags by appending `-Os` to `EE_CFLAGS` in exploit and launcher payloads

## Testing
- `make -C exploit clean all` *(fails: /samples/Makefile.eeglobal missing)*
- `make -C launcher-boot clean all` *(fails: /samples/Makefile.eeglobal missing)*
- `make -C launcher-keys clean all` *(fails: /samples/Makefile.eeglobal missing)*


------
https://chatgpt.com/codex/tasks/task_e_68ace59f45088321ad8cd47a8ecd7570