### PR TITLE
Remove gskit include paths from payload builds

### DIFF
--- a/launcher-boot/Makefile
+++ b/launcher-boot/Makefile
@@ -10,7 +10,7 @@ EE_BIN_PACKED= $(EE_TARGET)-packed.elf
 EE_OBJS = main.o       
 EE_LDFLAGS +=   -Wl,--gc-sections  -Wl,-Ttext -Wl,$(LOADADDR)  -Wl,--defsym -Wl,_stack_size=$(STACKSIZE) -Wl,--defsym -Wl,_stack=$(STACKADDR)
 EE_LIBS = -lc -lpatches 
-EE_INCS= -I$(GSKIT)/include -I$(PS2SDK)/ports/include
+EE_INCS= -I$(PS2SDK)/ports/include
 EE_CFLAGS += -Os
 
 

--- a/launcher-keys/Makefile
+++ b/launcher-keys/Makefile
@@ -10,7 +10,7 @@ EE_BIN_PACKED= $(EE_TARGET)-packed.elf
 EE_OBJS = main.o         pad.o
 EE_LDFLAGS +=   -Wl,--gc-sections  -Wl,-Ttext -Wl,$(LOADADDR)  -Wl,--defsym -Wl,_stack_size=$(STACKSIZE) -Wl,--defsym -Wl,_stack=$(STACKADDR)
 EE_LIBS = -lc -lpatches -lpad 
-EE_INCS= -I$(GSKIT)/include -I$(PS2SDK)/ports/include
+EE_INCS= -I$(PS2SDK)/ports/include
 EE_CFLAGS += -Os
 
 


### PR DESCRIPTION
## Summary
- clean up payload Makefiles by dropping unused gskit include path

## Testing
- `make -C launcher-boot` *(fails: /samples/Makefile.eeglobal: No such file or directory)*
- `make -C launcher-keys` *(fails: /samples/Makefile.eeglobal: No such file or directory)*
- `docker build . --tag opentuna-build:latest` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68ace84963f48321b88c54f884c6471c