### PR TITLE
docs: update README for native ps2-packer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@ Run `make -C exploit clean` to remove generated files.
 
 ### Continuous integration
 A GitHub Actions workflow builds the exploit on each push and pull request. The workflow
-builds a Docker image and runs the build inside a container:
+builds a Docker image (which compiles a native `ps2-packer` from `tools/ps2-packer`) and runs the build inside a container:
 
 ```yaml
 - name: Build the Docker image
   run: docker build . --tag opentuna-build:latest
 - name: Run the build in the container
   run: |
-    docker run --rm --user $(id -u):$(id -g) -v "${{ github.workspace }}":/app -w /app \
-    -e HOME=/app -e WINEPREFIX=/app/.wine \
+    docker run --rm -v "${{ github.workspace }}":/app -w /app \
+    -e HOME=/app \
     opentuna-build:latest \
-    bash -lc "mkdir -p $WINEPREFIX && make -C exploit"
+    bash -lc "make -C exploit"
 ```
 
 The compiled payload files (such as `payload.bin`) are written to the `exploit/` directory


### PR DESCRIPTION
## Summary
- document native ps2-packer compiled into Docker image
- update container build instructions to remove wine usage and match workflow

## Testing
- `make -C exploit` *(fails: Makefile:43: /samples/Makefile.eeglobal: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ace93374848321b2b3472da0f5d7b0