### PR TITLE
Add gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Ignore object files and dependencies
+*.o
+*.d
+*.a
+
+# Ignore binary outputs
+*.elf
+*.bin
+*.out
+*.exe
+
+# Generated exploit payload source
+exploit/payload_elf.c
+
+# Common build directories
+build/
+dist/


### PR DESCRIPTION
## Summary
- add a `.gitignore` at the repo root to exclude compiled objects, binary outputs and generated exploit sources

## Testing
- `make -C exploit` *(fails: No rule to make target '/samples/Makefile.eeglobal')*

------
https://chatgpt.com/codex/tasks/task_e_68ace9d0fa988321a544522887c5b11b