### PR TITLE
ci: install toolchain deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install toolchain prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev
+
       - name: Set up PS2 toolchain
         run: |
           git clone https://github.com/ps2dev/ps2toolchain.git


### PR DESCRIPTION
## Summary
- install libgmp, libmpfr and libmpc packages before building PS2 toolchain

## Testing
- `for f in depends/*.sh; do echo Running $f; bash $f || break; done`


------
https://chatgpt.com/codex/tasks/task_e_68acecf1e5108321b98330760828e5ca