### PR TITLE
ci: publish payload artifact and release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,3 +38,21 @@ jobs:
           -e HOME=/app \
           opentuna-build:latest \
           bash -lc "make -C exploit"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: opentuna-payload
+          path: exploit/payload.bin
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: opentuna-payload
+          path: exploit
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: exploit/payload.bin

--- a/README.md
+++ b/README.md
@@ -35,4 +35,6 @@ builds a Docker image (which compiles a native `ps2-packer` from `tools/ps2-pack
 ```
 
 The compiled payload files (such as `payload.bin`) are written to the `exploit/` directory
-and are available for download from the workflow run's artifact section.
+and are available for download from the workflow run's artifact section. When a tag is
+pushed, the workflow also creates a GitHub Release and attaches the payload artifact, so
+you can download `payload.bin` directly from the release page.


### PR DESCRIPTION
## Summary
- upload payload.bin as workflow artifact
- publish GitHub releases on tag pushes with attached payload
- document release artifacts in README

## Testing
- `make -C exploit` *(fails: No rule to make target '/samples/Makefile.eeglobal')*


------
https://chatgpt.com/codex/tasks/task_e_68ad1f0f8e1c832190fd52a37dc844f6