### PR TITLE
Simplify CI to use prebuilt PS2 toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,26 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install toolchain prerequisites
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev
-
-      - name: Set up PS2 toolchain
-        run: |
-          git clone https://github.com/ps2dev/ps2toolchain.git
-          cd ps2toolchain
-          ./toolchain.sh
-          echo "$HOME/ps2dev/bin" >> $GITHUB_PATH
-          echo "$HOME/ps2dev/ee/bin" >> $GITHUB_PATH
-
-      - name: Set up PS2SDK
-        run: |
-          git clone --depth=1 https://github.com/ps2dev/ps2sdk.git \
-            $HOME/ps2dev/ps2sdk
-          git clone --depth=1 https://github.com/ps2dev/ps2sdk-ports.git \
-            $HOME/ps2dev/ps2sdk-ports
-
       - name: Build the Docker image
         run: docker build . --tag opentuna-build:latest
 


### PR DESCRIPTION
## Summary
- remove PS2 toolchain and SDK setup steps
- rely on ps2dev/ps2dev Docker image to build payload

## Testing
- `docker build . --tag opentuna-build:latest` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*


------
https://chatgpt.com/codex/tasks/task_e_68ad1fd8b1648321b07917e9f26c1572