### PR TITLE
ci: pass toolchain paths to container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ jobs:
         run: |
           docker run --rm -v "${{ github.workspace }}":/app -w /app \
           -e HOME=/app \
+          -e PS2DEV=/usr/local/ps2dev \
+          -e PS2SDK=/usr/local/ps2dev/ps2sdk \
+          -e PATH=/usr/local/ps2dev/bin:/usr/local/bin:/usr/bin:/bin \
           opentuna-build:latest \
           bash -lc "make -C exploit"
 


### PR DESCRIPTION
## Summary
- ensure toolchain env vars are present when running container build

## Testing
- `docker build . --tag opentuna-build:latest` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68ad21918f348321bf5176bbf673e0b4