### PR TITLE
chore: pin action-gh-release to commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           name: opentuna-payload
           path: exploit
-      - uses: softprops/action-gh-release@v1
+      - uses: softprops/action-gh-release@fbadcc90e88ecface60a0a0d123795b784ceb239
+        # Pinned to commit fbadcc90e88ecface60a0a0d123795b784ceb239 for traceability
         with:
           files: exploit/payload.bin


### PR DESCRIPTION
## Summary
- pin softprops/action-gh-release to specific commit

## Testing
- `make -C exploit` *(fails: No rule to make target '/samples/Makefile.eeglobal')*


------
https://chatgpt.com/codex/tasks/task_e_68ad2275deec8321811b264a15ec871d