### PR TITLE
fix: correct exploit build step in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,15 +12,17 @@ jobs:
       - name: Build the Docker image
         run: docker build . --tag opentuna-build:latest
 
-      - name: Run the build in the container
+      - name: Build exploit in container
         run: |
-          docker run --rm -v "${{ github.workspace }}":/app -w /app \
-          -e HOME=/app \
-          -e PS2DEV=/usr/local/ps2dev \
-          -e PS2SDK=/usr/local/ps2dev/ps2sdk \
-          -e PATH=/usr/local/ps2dev/bin:/usr/local/bin:/usr/bin:/bin \
-          opentuna-build:latest \
-          bash -lc "make -C exploit"
+          docker run --rm \
+            -v "${{ github.workspace }}":/app \
+            -w /app \
+            -e HOME=/app \
+            -e PS2DEV=/usr/local/ps2dev \
+            -e PS2SDK=/usr/local/ps2dev/ps2sdk \
+            -e PATH=/usr/local/ps2dev/bin:/usr/local/ps2dev/ps2sdk/bin:$PATH \
+            opentuna-build:latest \
+            bash -lc "make -C exploit"
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- fix exploit build job to expose PS2 SDK binaries in PATH

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 180}}}' .github/workflows/build.yml`
- `docker build . --tag opentuna-build:latest` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68ad24aa7e5483218eb806cfdf16c38b