### PR TITLE
Attach payload artifact to releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: opentuna-payload
+          name: payload
           path: exploit/payload.bin
 
   release:
@@ -36,9 +36,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: opentuna-payload
-          path: exploit
+          name: payload
       - uses: softprops/action-gh-release@fbadcc90e88ecface60a0a0d123795b784ceb239
         # Pinned to commit fbadcc90e88ecface60a0a0d123795b784ceb239 for traceability
         with:
-          files: exploit/payload.bin
+          files: payload.bin


### PR DESCRIPTION
## Summary
- upload exploit payload as workflow artifact
- publish downloaded payload in tag-triggered releases

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 120}}}' .github/workflows/build.yml`

------
https://chatgpt.com/codex/tasks/task_e_68ad26f4d26083218f89f4c5d9727da0