### PR TITLE
Source PS2SDK env before building exploit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,14 +15,9 @@ jobs:
       - name: Build exploit in container
         run: |
           docker run --rm \
-            -v "${{ github.workspace }}":/app \
-            -w /app \
-            -e HOME=/app \
-            -e PS2DEV=/usr/local/ps2dev \
-            -e PS2SDK=/usr/local/ps2dev/ps2sdk \
-            -e PATH=/usr/local/ps2dev/bin:/usr/local/ps2dev/ps2sdk/bin:$PATH \
+            -v "${{ github.workspace }}":/app -w /app \
             opentuna-build:latest \
-            bash -lc "make -C exploit"
+            bash -lc "source /etc/profile && make -C exploit"
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- run `docker run` with `source /etc/profile` so PS2SDK env vars are loaded during build
- drop manual PS2SDK environment variables

## Testing
- `docker run --rm hello-world` *(fails: Cannot connect to the Docker daemon)*
- `mips64r5900el-ps2-elf-gcc --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2fa9c60c8321b69f6b0509da65ab