### PR TITLE
Modernize exploit build rules

### DIFF
--- a/exploit/Makefile
+++ b/exploit/Makefile
@@ -13,20 +13,20 @@ EE_TARGET=payload
 EE_BIN = $(EE_TARGET).elf
 EE_BIN_RAW = $(EE_TARGET).bin
 EE_BIN_STRIPPED = $(EE_TARGET)-stripped.elf
-EE_OBJS = main.o   payload_elf.o
-EE_LDFLAGS +=  -nostartfiles  -Wl,-Ttext -Wl,$(LOADADDR)   -Wl,--gc-sections
+EE_SRCS = main.c payload_elf.c
+EE_LDFLAGS += -nostartfiles -Wl,-Ttext=$(LOADADDR) -Wl,--gc-sections
 EE_CFLAGS += -Os
 
-all:
-	$(MAKE) $(EE_BIN_RAW)
-
-payload_elf.o: payload_elf.c
-	$(EE_CC) $(EE_CFLAGS) -c $< -o $@
+all: payload_elf.c $(EE_BIN_RAW)
 
 payload_elf.c: ../$(PAYLOAD)/payload-packed.elf ../tools/bin2c/bin2c
-	$(MAKE) -C ../$(PAYLOAD)
-	$(MAKE) -C ../tools/bin2c
 	../tools/bin2c/bin2c $< $@ payload_elf
+
+../$(PAYLOAD)/payload-packed.elf:
+	$(MAKE) -C ../$(PAYLOAD)
+
+../tools/bin2c/bin2c:
+	$(MAKE) -C ../tools/bin2c
 
 clean:
 	$(MAKE) -C ../$(PAYLOAD)/ clean
@@ -39,5 +39,5 @@ $(EE_BIN_STRIPPED): $(EE_BIN)
 $(EE_BIN_RAW): $(EE_BIN_STRIPPED)
 	$(EE_OBJCOPY) -O binary -v $< $@
 
-include $(PS2SDK)/samples/Makefile.pref
-include $(PS2SDK)/samples/Makefile.eeglobal
+include $(PS2SDK)/Defs.make
+include $(PS2SDK)/Rules.make


### PR DESCRIPTION
## Summary
- modernize exploit build to use Defs.make/Rules.make
- simplify object handling with EE_SRCS and update linker flags
- ensure payload_elf.c and tools build before compilation

## Testing
- `make` *(fails: /Rules.make: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3249d9e4832186e10039dad4a944