### PR TITLE
Update exploit Makefile for new PS2SDK

### DIFF
--- a/exploit/Makefile
+++ b/exploit/Makefile
@@ -13,11 +13,13 @@ EE_TARGET=payload
 EE_BIN = $(EE_TARGET).elf
 EE_BIN_RAW = $(EE_TARGET).bin
 EE_BIN_STRIPPED = $(EE_TARGET)-stripped.elf
-EE_SRCS = main.c payload_elf.c
-EE_LDFLAGS += -nostartfiles -Wl,-Ttext=$(LOADADDR) -Wl,--gc-sections
+EE_SRCS = main.c
+EE_OBJS += payload_elf.o
+EE_LDFLAGS += -nostartfiles -Wl,-Ttext=$(LOADADDR),--gc-sections
+EE_LIBS = -lc -lpatches
 EE_CFLAGS += -Os
 
-all: payload_elf.c $(EE_BIN_RAW)
+all: $(EE_BIN_RAW)
 
 payload_elf.c: ../$(PAYLOAD)/payload-packed.elf ../tools/bin2c/bin2c
 	../tools/bin2c/bin2c $< $@ payload_elf


### PR DESCRIPTION
## Summary
- modernize exploit Makefile to use PS2SDK build rules
- switch EE source list to main.c and link payload_elf.o
- add compact linker flags and required libraries

## Testing
- `make -C launcher-boot clean` *(fails: /Rules.make: No such file or directory)*
- `make -C exploit clean` *(fails: /Rules.make: No such file or directory)*
- `apt-get install -y ps2sdk` *(fails: Unable to locate package ps2sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68ad35a508008321b44e1be9db21a3a0