### PR TITLE
Specify artifact download path for release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: payload
+          path: .
       - uses: softprops/action-gh-release@fbadcc90e88ecface60a0a0d123795b784ceb239
         # Pinned to commit fbadcc90e88ecface60a0a0d123795b784ceb239 for traceability
         with:


### PR DESCRIPTION
## Summary
- ensure release workflow downloads payload artifact to repository root

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68ad37e98054832196c067b0302c8b84