### PR TITLE
Install PS2SDK in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ RUN apk add --no-cache \
     zlib-dev \
     bash
 
+RUN git clone --depth=1 https://github.com/ps2dev/ps2sdk.git /tmp/ps2sdk \
+    && cd /tmp/ps2sdk && make install \
+    && rm -rf /tmp/ps2sdk
+
 COPY tools/ps2-packer /tmp/ps2-packer
 RUN make -C /tmp/ps2-packer ps2-packer-lite && \
     cp /tmp/ps2-packer/ps2-packer-lite /usr/local/bin/ps2-packer && \


### PR DESCRIPTION
## Summary
- Install latest PS2SDK during image build

## Testing
- `docker build -t opentuna-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `make -C exploit` *(fails: /Rules.make: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68adc132bcd08321a721608619cbfa6e