### PR TITLE
Set PS2 env vars when building exploit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,11 @@ jobs:
         run: |
           docker run --rm \
             -v "${{ github.workspace }}":/app -w /app \
+            -e PS2DEV=/usr/local/ps2dev \
+            -e PS2SDK=/usr/local/ps2dev/ps2sdk \
+            -e PATH=/usr/local/ps2dev/bin:/usr/local/ps2dev/ps2sdk/bin:$PATH \
             opentuna-build:latest \
-            bash -lc "source /etc/profile && make -C exploit"
+            bash -lc "make -C exploit"
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- set PS2 toolchain environment variables for exploit build step in CI

## Testing
- `dockerd > /tmp/dockerd.log 2>&1` *(fails: failed to mount overlay: operation not permitted)*
- `make -C exploit` *(fails: No rule to make target '/Rules.make')*

------
https://chatgpt.com/codex/tasks/task_e_68adc1efa04c8321a248c0918d9891a3