### PR TITLE
Add git and build tools to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM ps2dev/ps2dev:latest
 
 RUN apk add --no-cache \
-    make \
-    gcc \
-    libc-dev \
+    git \
+    build-base \
     zlib-dev \
     bash
 


### PR DESCRIPTION
## Summary
- Install git, build-base, zlib-dev, and bash to provide the PS2SDK build environment.

## Testing
- ❌ `docker build -t test .` *(Cannot connect to Docker daemon: unix:///var/run/docker.sock. Daemon could not start due to permission errors.)*

------
https://chatgpt.com/codex/tasks/task_e_68adc45594908321b98731e2938a1b08