### PR TITLE
Expose PS2 development environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,6 @@ RUN make -C /tmp/ps2-packer ps2-packer-lite && \
     cp /tmp/ps2-packer/ps2-packer-lite /usr/local/bin/ps2-packer && \
     rm -rf /tmp/ps2-packer
 
+ENV PS2DEV=/usr/local/ps2dev \
+    PS2SDK=/usr/local/ps2dev/ps2sdk \
+    PATH=/usr/local/ps2dev/bin:/usr/local/ps2dev/ps2sdk/bin:$PATH


### PR DESCRIPTION
## Summary
- add PS2DEV, PS2SDK and updated PATH environment variables in Dockerfile

## Testing
- `podman build --storage-driver=vfs -t opentuna-ps2dev -f Dockerfile.tmp .` *(fails: error mounting "proc" to rootfs: operation not permitted)*

------
https://chatgpt.com/codex/tasks/task_e_68adca6599388321a401eb47879f53d9