### PR TITLE
docs: align CI build snippet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
         run: docker build . --tag opentuna-build:latest
 
       - name: Build exploit in container
+        # Run the exploit build inside the Docker container
         run: |
           docker run --rm \
             -v "${{ github.workspace }}":/app -w /app \

--- a/README.md
+++ b/README.md
@@ -26,12 +26,15 @@ builds a Docker image (which compiles a native `ps2-packer` from `tools/ps2-pack
 ```yaml
 - name: Build the Docker image
   run: docker build . --tag opentuna-build:latest
-- name: Run the build in the container
+- name: Build exploit in container
   run: |
     docker run --rm \
       -v "${{ github.workspace }}":/app -w /app \
+      -e PS2DEV=/usr/local/ps2dev \
+      -e PS2SDK=/usr/local/ps2dev/ps2sdk \
+      -e PATH=/usr/local/ps2dev/bin:/usr/local/ps2dev/ps2sdk/bin:$PATH \
       opentuna-build:latest \
-      bash -lc "source /etc/profile && make -C exploit"
+      bash -lc "make -C exploit"
 ```
 
 The compiled payload files (such as `payload.bin`) are written to the `exploit/` directory,


### PR DESCRIPTION
## Summary
- describe container build step in workflow
- mirror workflow snippet in README CI example

## Testing
- `make -C exploit` *(fails: Makefile:45: /Rules.make: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68adccc98b8883219cd320b9496529e3