### PR TITLE
build: upload payload artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: payload
+          name: opentuna-payload
           path: exploit/payload.bin
 
   release:
@@ -35,8 +35,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: payload
-          path: .
+          name: opentuna-payload
       - uses: softprops/action-gh-release@fbadcc90e88ecface60a0a0d123795b784ceb239
         # Pinned to commit fbadcc90e88ecface60a0a0d123795b784ceb239 for traceability
         with:


### PR DESCRIPTION
## Summary
- upload the built payload as a reusable workflow artifact
- publish payload.bin to GitHub Releases when tags are pushed

## Testing
- `make -C exploit` *(fails: No rule to make target '/Rules.make')*


------
https://chatgpt.com/codex/tasks/task_e_68adcdc55df48321afbc0d0f79cd2380