### PR TITLE
build: annotate PS2SDK install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ps2dev/ps2dev:latest
+FROM docker.io/ps2dev/ps2dev:latest
 
 RUN apk add --no-cache \
     git \
@@ -6,6 +6,7 @@ RUN apk add --no-cache \
     zlib-dev \
     bash
 
+# Install PS2SDK
 RUN git clone --depth=1 https://github.com/ps2dev/ps2sdk.git /tmp/ps2sdk \
     && cd /tmp/ps2sdk && make install \
     && rm -rf /tmp/ps2sdk


### PR DESCRIPTION
## Summary
- qualify ps2dev base image for clarity
- document PS2SDK installation step in Dockerfile

## Testing
- `docker version` *(fails: Cannot connect to the Docker daemon)*
- `podman build -t test-ps2sdk .` *(fails: operation not permitted when mounting /proc)*

------
https://chatgpt.com/codex/tasks/task_e_68add1c1ed088321bc893483ad710312