### PR TITLE
Build exploit inside container in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ jobs:
         run: docker build . --tag opentuna-build:latest
 
       - name: Build exploit in container
-        # Run the exploit build inside the Docker container
         run: |
           docker run --rm \
             -v "${{ github.workspace }}":/app -w /app \


### PR DESCRIPTION
## Summary
- replace build step in CI workflow to build exploit within container

## Testing
- `make -C exploit` *(fails: No rule to make target '/Rules.make')*


------
https://chatgpt.com/codex/tasks/task_e_68add444d9388321af7d35634f7ae10e