### PR TITLE
Generate payload source before dependency scan

### DIFF
--- a/exploit/Makefile
+++ b/exploit/Makefile
@@ -14,7 +14,7 @@ EE_BIN = $(EE_TARGET).elf
 EE_BIN_RAW = $(EE_TARGET).bin
 EE_BIN_STRIPPED = $(EE_TARGET)-stripped.elf
 EE_SRCS = main.c
-EE_OBJS += payload_elf.o
+EE_SRCS += payload_elf.c
 EE_LDFLAGS += -nostartfiles -Wl,-Ttext=$(LOADADDR),--gc-sections
 EE_LIBS = -lc -lpatches
 EE_CFLAGS += -Os
@@ -39,7 +39,12 @@ $(EE_BIN_STRIPPED): $(EE_BIN)
 
 #Rule for raw binary to embed into icon.icn
 $(EE_BIN_RAW): $(EE_BIN_STRIPPED)
-	$(EE_OBJCOPY) -O binary -v $< $@
+	        $(EE_OBJCOPY) -O binary -v $< $@
+
+# Ensure generated source exists before dependency scanning
+ifeq ($(filter payload_elf.c,$(MAKECMDGOALS)),)
+$(shell $(MAKE) --no-print-directory -C $(CURDIR) payload_elf.c >/dev/null)
+endif
 
 include $(PS2SDK)/Defs.make
 include $(PS2SDK)/Rules.make


### PR DESCRIPTION
## Summary
- compile `payload_elf.c` instead of object and generate it before dependency scanning

## Testing
- `make` *(fails: Makefile:50: /Rules.make: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68add64642808321bfd3c91410ab507a