### PR TITLE
refactor: remove EE_INCS assignments

### DIFF
--- a/launcher-boot/Makefile
+++ b/launcher-boot/Makefile
@@ -10,7 +10,6 @@ EE_BIN_PACKED= $(EE_TARGET)-packed.elf
 EE_SRCS = main.c
 EE_LDFLAGS += -Wl,-Ttext=$(LOADADDR),--defsym,_stack_size=$(STACKSIZE),--defsym,_stack=$(STACKADDR),--gc-sections
 EE_LIBS = -lc -lpatches 
-EE_INCS= -I$(PS2SDK)/ports/include
 EE_CFLAGS += -Os
 
 
@@ -37,5 +36,6 @@ $(EE_BIN_PACKED): $(EE_BIN_STRIPPED)
 
 	
 include $(PS2SDK)/Defs.make
+EE_CFLAGS += -I$(PS2SDK)/ports/include
 include $(PS2SDK)/Rules.make
 

--- a/launcher-keys/Makefile
+++ b/launcher-keys/Makefile
@@ -10,7 +10,6 @@ EE_BIN_PACKED= $(EE_TARGET)-packed.elf
 EE_SRCS = main.c pad.c
 EE_LDFLAGS += -Wl,-Ttext=$(LOADADDR),--defsym,_stack_size=$(STACKSIZE),--defsym,_stack=$(STACKADDR),--gc-sections
 EE_LIBS = -lc -lpatches -lpad 
-EE_INCS= -I$(PS2SDK)/ports/include
 EE_CFLAGS += -Os
 
 
@@ -37,5 +36,6 @@ $(EE_BIN_PACKED): $(EE_BIN_STRIPPED)
 
 	
 include $(PS2SDK)/Defs.make
+EE_CFLAGS += -I$(PS2SDK)/ports/include
 include $(PS2SDK)/Rules.make
 


### PR DESCRIPTION
## Summary
- remove `EE_INCS` usage from payload Makefiles
- add port include path to `EE_CFLAGS` after `Defs.make`

## Testing
- `apt-get install -y ps2sdk` *(fails: Unable to locate package ps2sdk)*
- `make clean` *(launcher-boot: No such file or directory /Rules.make)*
- `make clean` *(launcher-keys: No such file or directory /Rules.make)*

------
https://chatgpt.com/codex/tasks/task_e_68add744cf54832182aa9ff6014650da