### PR TITLE
fix: run exploit build in configured container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,8 @@ jobs:
         run: |
           docker run --rm \
             -v "${{ github.workspace }}":/app -w /app \
-            -e PS2DEV=/usr/local/ps2dev \
-            -e PS2SDK=/usr/local/ps2dev/ps2sdk \
-            -e PATH=/usr/local/ps2dev/bin:/usr/local/ps2dev/ps2sdk/bin:$PATH \
             opentuna-build:latest \
-            bash -lc "make -C exploit"
+            bash -lc "source /etc/profile && make -C exploit"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -28,13 +28,10 @@ builds a Docker image (which compiles a native `ps2-packer` from `tools/ps2-pack
   run: docker build . --tag opentuna-build:latest
 - name: Build exploit in container
   run: |
-    docker run --rm \
-      -v "${{ github.workspace }}":/app -w /app \
-      -e PS2DEV=/usr/local/ps2dev \
-      -e PS2SDK=/usr/local/ps2dev/ps2sdk \
-      -e PATH=/usr/local/ps2dev/bin:/usr/local/ps2dev/ps2sdk/bin:$PATH \
-      opentuna-build:latest \
-      bash -lc "make -C exploit"
+    docker run --rm \\
+      -v "${{ github.workspace }}":/app -w /app \\
+      opentuna-build:latest \\
+      bash -lc "source /etc/profile && make -C exploit"
 - uses: actions/upload-artifact@v4
   with:
     name: opentuna-payload

--- a/launcher-boot/Makefile
+++ b/launcher-boot/Makefile
@@ -36,6 +36,5 @@ $(EE_BIN_PACKED): $(EE_BIN_STRIPPED)
 
 	
 include $(PS2SDK)/Defs.make
-EE_CFLAGS += -I$(PS2SDK)/ports/include
 include $(PS2SDK)/Rules.make
 

--- a/launcher-keys/Makefile
+++ b/launcher-keys/Makefile
@@ -36,6 +36,5 @@ $(EE_BIN_PACKED): $(EE_BIN_STRIPPED)
 
 	
 include $(PS2SDK)/Defs.make
-EE_CFLAGS += -I$(PS2SDK)/ports/include
 include $(PS2SDK)/Rules.make
 


### PR DESCRIPTION
## Summary
- run exploit build within the docker image that already exposes PS2 toolchain
- drop obsolete port include flags from launcher makefiles
- document simplified docker run command

## Testing
- `make -C exploit` *(fails: No rule to make target '/Rules.make')*


------
https://chatgpt.com/codex/tasks/task_e_68acec994e108321bf13c04062a0786c