### PR TITLE
ci: build exploit using opentuna-build image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,8 @@ jobs:
             -e PS2DEV=/usr/local/ps2dev \
             -e PS2SDK=/usr/local/ps2dev/ps2sdk \
             -e PATH=/usr/local/ps2dev/bin:/usr/local/ps2dev/ps2sdk/bin:$PATH \
-            bash -lc "source /etc/profile && make -C exploit"
+            opentuna-build:latest \
+            bash -lc "make -C exploit"
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- run exploit build in pre-built opentuna-build container image

## Testing
- `docker build . --tag opentuna-build:latest` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*
- `make -C exploit` *(fails: No rule to make target '/Rules.make'. Stop.)*


------
https://chatgpt.com/codex/tasks/task_e_68addd1cfef08321a89e520a647945ff