### PR TITLE
Make _start a normal function

### DIFF
--- a/exploit/main.c
+++ b/exploit/main.c
@@ -51,7 +51,7 @@ typedef struct
 
 
 
-static inline void _start()
+void _start(void)
 {
         uint8_t *boot_elf;
 	elf_header_t *eh;


### PR DESCRIPTION
## Summary
- expose `_start` as a non-static function so it appears in symbol table

## Testing
- `make` *(fails: No rule to make target '/Rules.make')*
- `mipsel-linux-gnu-nm main.o | grep _start`


------
https://chatgpt.com/codex/tasks/task_e_68af3242622483219caefa511629c493