### PR TITLE
Cast vaddr to byte pointer before memset

### DIFF
--- a/exploit/main.c
+++ b/exploit/main.c
@@ -82,9 +82,9 @@ void _start(void)
 		pdata = (void *)(boot_elf + eph[i].offset);
 		memcpy(eph[i].vaddr, pdata, eph[i].filesz);
 
-		if (eph[i].memsz > eph[i].filesz)
-			memset(eph[i].vaddr + eph[i].filesz, 0,
-				   eph[i].memsz - eph[i].filesz);
+                if (eph[i].memsz > eph[i].filesz)
+                        memset((uint8_t*)eph[i].vaddr + eph[i].filesz, 0,
+                                   eph[i].memsz - eph[i].filesz);
 	}
 
 	/* Let's go.  */


### PR DESCRIPTION
## Summary
- fix memset call in exploit loader by casting `vaddr` to `uint8_t*` before pointer arithmetic

## Testing
- `make` *(fails: Makefile:50: /Rules.make: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af333cbbd08321b3ce27d2b8d86cd3