### PR TITLE
Use const char* for file_exists in launcher programs

### DIFF
--- a/launcher-boot/main.c
+++ b/launcher-boot/main.c
@@ -80,9 +80,9 @@ void LoadElf(char *filename, char *party)
 	}
 }
 
-int file_exists(char filepath[])
+int file_exists(const char *filepath)
 {
-	int fdn;
+        int fdn;
 
 	fdn = open(filepath, O_RDONLY);
 	if (fdn < 0)

--- a/launcher-keys/main.c
+++ b/launcher-keys/main.c
@@ -98,9 +98,9 @@ void LoadElf(char *filename, char *party)
 	}
 }
 
-int file_exists(char filepath[])
+int file_exists(const char *filepath)
 {
-	int fdn;
+        int fdn;
 
 	fdn = open(filepath, O_RDONLY);
 	if (fdn < 0)


### PR DESCRIPTION
## Summary
- Update launcher-boot and launcher-keys to take `const char *` in `file_exists`

## Testing
- `cd launcher-boot && make` *(fails: Makefile:39: /Rules.make: No such file or directory)*
- `cd launcher-keys && make` *(fails: Makefile:39: /Rules.make: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af33d2e7fc8321ad23e06e7032c6b4