### PR TITLE
Fix early Japanese BIOS check in launcher-keys

### DIFF
--- a/launcher-keys/main.c
+++ b/launcher-keys/main.c
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
 	ROMVersionNumStr[4] = '\0';
 	bios_version = strtoul(ROMVersionNumStr, NULL, 16);
 
-	if ((romver_region_char[0] == 'J') && (bios_version <= 0x120))
+	if ((romver_region_char[0] == 'I') && (bios_version <= 0x120))
 		isEarlyJap = 1;
 
 	//Stores last key during DELAY msec


### PR DESCRIPTION
## Summary
- Ensure early Japanese BIOS detection compares against the `'I'` region code stored for Japanese consoles.

## Testing
- `cd launcher-keys && make` *(fails: Makefile:39: /Rules.make: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af34907adc83218ea6f56fa88f1644