### PR TITLE
Switch launchers to fileXio API

### DIFF
--- a/launcher-boot/Makefile
+++ b/launcher-boot/Makefile
@@ -7,7 +7,7 @@ EE_BIN_STRIPPED = payload-stripped.elf
 EE_BIN_PACKED = payload-packed.elf
 EE_OBJS = main.o
 EE_LDFLAGS += -Wl,--gc-sections -Wl,-Ttext -Wl,$(LOADADDR) -Wl,--defsym -Wl,_stack_size=$(STACKSIZE) -Wl,--defsym -Wl,_stack=$(STACKADDR)
-EE_LIBS += -lpatches
+EE_LIBS += -lpatches -lfileXio
 EE_INCS += -I$(GSKIT)/include -I$(PS2SDK)/ports/include
 EE_CFLAGS += -Os
 

--- a/launcher-boot/main.c
+++ b/launcher-boot/main.c
@@ -4,7 +4,7 @@
 #include <kernel.h>
 #include <sifrpc.h>
 #include <loadfile.h>
-#include <stdio.h>
+#include <fileXio_rpc.h>
 #include <unistd.h>
 #include <time.h>
 #include <string.h>
@@ -13,7 +13,6 @@
 #include <fcntl.h>
 #include <sbv_patches.h>
 
-#include <stdio.h>
 #include <debug.h>
 #include <fcntl.h>
 #include <stdlib.h>
@@ -51,7 +50,7 @@ void InitPS2()
 	ResetIOP();
 	SifInitIopHeap();
 	SifLoadFileInit();
-	fioInit();
+        fileXioInit();
 	sbv_patch_disable_prefix_check();
 	SifLoadModule("rom0:SIO2MAN", 0, NULL);
 	SifLoadModule("rom0:MCMAN", 0, NULL);
@@ -85,10 +84,10 @@ int file_exists(char filepath[])
 {
 	int fdn;
 
-	fdn = open(filepath, O_RDONLY);
-	if (fdn < 0)
-		return 0;
-	close(fdn);
+        fdn = fileXioOpen(filepath, O_RDONLY);
+        if (fdn < 0)
+                return 0;
+        fileXioClose(fdn);
 
 	return 1;
 }

--- a/launcher-keys/Makefile
+++ b/launcher-keys/Makefile
@@ -7,7 +7,7 @@ EE_BIN_STRIPPED = payload-stripped.elf
 EE_BIN_PACKED = payload-packed.elf
 EE_OBJS = main.o pad.o
 EE_LDFLAGS += -Wl,--gc-sections -Wl,-Ttext -Wl,$(LOADADDR) -Wl,--defsym -Wl,_stack_size=$(STACKSIZE) -Wl,--defsym -Wl,_stack=$(STACKADDR)
-EE_LIBS += -lpatches -lpad
+EE_LIBS += -lpatches -lpad -lfileXio
 EE_INCS += -I$(GSKIT)/include -I$(PS2SDK)/ports/include
 EE_CFLAGS += -Os
 

--- a/launcher-keys/main.c
+++ b/launcher-keys/main.c
@@ -4,7 +4,7 @@
 #include <kernel.h>
 #include <sifrpc.h>
 #include <loadfile.h>
-#include <stdio.h>
+#include <fileXio_rpc.h>
 #include <unistd.h>
 #include <time.h>
 #include <string.h>
@@ -13,11 +13,8 @@
 #include <fcntl.h>
 #include <sbv_patches.h>
 #include <libpad.h>
-#include <stdio.h>
 #include <debug.h>
-#include <fcntl.h>
 #include <stdlib.h>
-#include <string.h>
 #include <stdint.h>
 
 #define NTSC 2
@@ -64,7 +61,7 @@ void InitPS2()
 	ResetIOP();
 	SifInitIopHeap();
 	SifLoadFileInit();
-	fioInit();
+        fileXioInit();
 	sbv_patch_disable_prefix_check();
 	SifLoadModule("rom0:SIO2MAN", 0, NULL);
 	SifLoadModule("rom0:MCMAN", 0, NULL);
@@ -102,10 +99,10 @@ int file_exists(char filepath[])
 {
 	int fdn;
 
-	fdn = open(filepath, O_RDONLY);
-	if (fdn < 0)
-		return 0;
-	close(fdn);
+    fdn = fileXioOpen(filepath, O_RDONLY);
+    if (fdn < 0)
+        return 0;
+    fileXioClose(fdn);
 
 	return 1;
 }
@@ -121,11 +118,11 @@ int main(int argc, char *argv[])
 	InitPS2();
 
 	int fdnr;
-	if ((fdnr = open("rom0:ROMVER", O_RDONLY)) > 0)
-	{ // Reading ROMVER
-		read(fdnr, romver, sizeof romver);
-		close(fdnr);
-	}
+    if ((fdnr = fileXioOpen("rom0:ROMVER", O_RDONLY)) > 0)
+    { // Reading ROMVER
+            fileXioRead(fdnr, romver, sizeof romver);
+            fileXioClose(fdnr);
+    }
 
 	// Getting region char
 	romver_region_char[0] = (romver[4] == 'E' ? 'E' : (romver[4] == 'J' ? 'I' : (romver[4] == 'H' ? 'A' : (romver[4] == 'U' ? 'A' : romver[4]))));


### PR DESCRIPTION
## Summary
- use fileXio for I/O in launcher-boot and launcher-keys
- link launchers against `-lfileXio`

## Testing
- `cd launcher-boot && make clean && make` *(fails: `/samples/Makefile.eeglobal: No such file or directory`)*
- `cd launcher-keys && make clean && make` *(fails: `/samples/Makefile.eeglobal: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68af60c0276083218ed4c3ba91364619