### PR TITLE
Refactor launchers to use shared loader

### DIFF
--- a/common/loader.c
+++ b/common/loader.c
@@ -1,0 +1,80 @@
+#include "loader.h"
+#include <iopcontrol.h>
+#include <iopheap.h>
+#include <kernel.h>
+#include <sifrpc.h>
+#include <loadfile.h>
+#include <fileXio_rpc.h>
+#include <sbv_patches.h>
+#include <fcntl.h>
+
+void wipeUserMem(void)
+{
+        int i;
+        for (i = 0x100000; i < GetMemorySize(); i += 64)
+        {
+                asm volatile(
+                        "\tsq $0, 0(%0) \n"
+                        "\tsq $0, 16(%0) \n"
+                        "\tsq $0, 32(%0) \n"
+                        "\tsq $0, 48(%0) \n" :: "r"(i));
+        }
+}
+
+void ResetIOP(void)
+{
+        SifInitRpc(0);
+        while (!SifIopReset("", 0))
+        {
+        };
+        while (!SifIopSync())
+        {
+        };
+        SifInitRpc(0);
+}
+
+void InitPS2(void)
+{
+        ResetIOP();
+        SifInitIopHeap();
+        SifLoadFileInit();
+        fileXioInit();
+        sbv_patch_disable_prefix_check();
+        SifLoadModule("rom0:SIO2MAN", 0, NULL);
+        SifLoadModule("rom0:MCMAN", 0, NULL);
+        SifLoadModule("rom0:MCSERV", 0, NULL);
+}
+
+void LoadElf(char *filename, char *party)
+{
+        char *args[1];
+        t_ExecData exec;
+        SifLoadElf(filename, &exec);
+
+        if (exec.epc > 0)
+        {
+                ResetIOP();
+
+                if (party != 0)
+                {
+                        args[0] = party;
+                        ExecPS2((void *)exec.epc, (void *)exec.gp, 1, args);
+                }
+                else
+                {
+                        ExecPS2((void *)exec.epc, (void *)exec.gp, 0, NULL);
+                }
+        }
+}
+
+int file_exists(char filepath[])
+{
+        int fdn;
+
+        fdn = fileXioOpen(filepath, O_RDONLY);
+        if (fdn < 0)
+                return 0;
+        fileXioClose(fdn);
+
+        return 1;
+}

--- a/common/loader.h
+++ b/common/loader.h
@@ -1,0 +1,10 @@
+#ifndef LOADER_H
+#define LOADER_H
+
+void wipeUserMem(void);
+void ResetIOP(void);
+void InitPS2(void);
+void LoadElf(char *filename, char *party);
+int file_exists(char filepath[]);
+
+#endif /* LOADER_H */

--- a/launcher-boot/Makefile
+++ b/launcher-boot/Makefile
@@ -5,7 +5,7 @@ STACKSIZE = 0x04000
 EE_BIN = payload.elf
 EE_BIN_STRIPPED = payload-stripped.elf
 EE_BIN_PACKED = payload-packed.elf
-EE_OBJS = main.o
+EE_OBJS = main.o ../common/loader.o
 EE_LDFLAGS += -Wl,--gc-sections -Wl,-Ttext -Wl,$(LOADADDR) -Wl,--defsym -Wl,_stack_size=$(STACKSIZE) -Wl,--defsym -Wl,_stack=$(STACKADDR)
 EE_LIBS += -lpatches -lfileXio
 EE_INCS += -I$(GSKIT)/include -I$(PS2SDK)/ports/include

--- a/launcher-boot/main.c
+++ b/launcher-boot/main.c
@@ -1,114 +1,21 @@
-
-#include <iopcontrol.h>
-#include <iopheap.h>
-#include <kernel.h>
-#include <sifrpc.h>
-#include <loadfile.h>
-#include <fileXio_rpc.h>
-#include <unistd.h>
-#include <time.h>
-#include <string.h>
-#include <libcdvd.h>
-
-#include <fcntl.h>
-#include <sbv_patches.h>
-
-#include <debug.h>
-#include <fcntl.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdint.h>
-
-static void wipeUserMem(void)
-{
-	int i;
-	for (i = 0x100000; i < GetMemorySize(); i += 64)
-	{
-		asm volatile(
-			"\tsq $0, 0(%0) \n"
-			"\tsq $0, 16(%0) \n"
-			"\tsq $0, 32(%0) \n"
-			"\tsq $0, 48(%0) \n" ::"r"(i));
-	}
-}
-
-void ResetIOP()
-{
-	SifInitRpc(0);
-	while (!SifIopReset("", 0))
-	{
-	};
-	while (!SifIopSync())
-	{
-	};
-	SifInitRpc(0);
-}
-
-void InitPS2()
-{
-	//init_scr();
-	ResetIOP();
-	SifInitIopHeap();
-	SifLoadFileInit();
-        fileXioInit();
-	sbv_patch_disable_prefix_check();
-	SifLoadModule("rom0:SIO2MAN", 0, NULL);
-	SifLoadModule("rom0:MCMAN", 0, NULL);
-	SifLoadModule("rom0:MCSERV", 0, NULL);
-}
-
-void LoadElf(char *filename, char *party)
-{
-
-	char *args[1];
-	t_ExecData exec;
-	SifLoadElf(filename, &exec);
-
-	if (exec.epc > 0)
-	{
-		ResetIOP();
-
-		if (party != 0)
-		{
-			args[0] = party;
-			ExecPS2((void *)exec.epc, (void *)exec.gp, 1, args);
-		}
-		else
-		{
-			ExecPS2((void *)exec.epc, (void *)exec.gp, 0, NULL);
-		}
-	}
-}
-
-int file_exists(char filepath[])
-{
-	int fdn;
-
-        fdn = fileXioOpen(filepath, O_RDONLY);
-        if (fdn < 0)
-                return 0;
-        fileXioClose(fdn);
-
-	return 1;
-}
+#include "../common/loader.h"
 
 int main(int argc, char *argv[])
 {
+        wipeUserMem();
 
-	wipeUserMem();
+        InitPS2();
 
-	InitPS2();
+        if (file_exists("mc0:/BOOT/BOOT.ELF"))
+                LoadElf("mc0:/BOOT/BOOT.ELF", "mc0:/BOOT/");
 
-	if (file_exists("mc0:/BOOT/BOOT.ELF"))
-		LoadElf("mc0:/BOOT/BOOT.ELF", "mc0:/BOOT/");
+        if (file_exists("mc1:/BOOT/BOOT.ELF"))
+                LoadElf("mc1:/BOOT/BOOT.ELF", "mc1:/BOOT/");
 
-	if (file_exists("mc1:/BOOT/BOOT.ELF"))
-		LoadElf("mc1:/BOOT/BOOT.ELF", "mc1:/BOOT/");
+        __asm__ __volatile__(
+                "       li $3, 0x04;"
+                "       syscall;"
+                "       nop;");
 
-	__asm__ __volatile__(
-		"	li $3, 0x04;"
-		"	syscall;"
-		"	nop;");
-
-	return 0;
+        return 0;
 }

--- a/launcher-keys/Makefile
+++ b/launcher-keys/Makefile
@@ -5,7 +5,7 @@ STACKSIZE = 0x04000
 EE_BIN = payload.elf
 EE_BIN_STRIPPED = payload-stripped.elf
 EE_BIN_PACKED = payload-packed.elf
-EE_OBJS = main.o pad.o
+EE_OBJS = main.o pad.o ../common/loader.o
 EE_LDFLAGS += -Wl,--gc-sections -Wl,-Ttext -Wl,$(LOADADDR) -Wl,--defsym -Wl,_stack_size=$(STACKSIZE) -Wl,--defsym -Wl,_stack=$(STACKADDR)
 EE_LIBS += -lpatches -lpad -lfileXio
 EE_INCS += -I$(GSKIT)/include -I$(PS2SDK)/ports/include

--- a/launcher-keys/main.c
+++ b/launcher-keys/main.c
@@ -1,21 +1,11 @@
-
-#include <iopcontrol.h>
-#include <iopheap.h>
-#include <kernel.h>
-#include <sifrpc.h>
+#include <tamtypes.h>
 #include <loadfile.h>
 #include <fileXio_rpc.h>
-#include <unistd.h>
-#include <time.h>
-#include <string.h>
-#include <libcdvd.h>
-
-#include <fcntl.h>
-#include <sbv_patches.h>
 #include <libpad.h>
-#include <debug.h>
 #include <stdlib.h>
-#include <stdint.h>
+#include <string.h>
+#include <fcntl.h>
+#include "../common/loader.h"
 
 #define NTSC 2
 #define PAL 3
@@ -30,159 +20,85 @@ char ROMVersionNumStr[5];
 u8 romver[16];
 u32 bios_version = 0;
 
-static void wipeUserMem(void)
-{
-	int i;
-	for (i = 0x100000; i < GetMemorySize(); i += 64)
-	{
-		asm volatile(
-			"\tsq $0, 0(%0) \n"
-			"\tsq $0, 16(%0) \n"
-			"\tsq $0, 32(%0) \n"
-			"\tsq $0, 48(%0) \n" ::"r"(i));
-	}
-}
-
-void ResetIOP()
-{
-	SifInitRpc(0);
-	while (!SifIopReset("", 0))
-	{
-	};
-	while (!SifIopSync())
-	{
-	};
-	SifInitRpc(0);
-}
-
-void InitPS2()
-{
-	//init_scr();
-	ResetIOP();
-	SifInitIopHeap();
-	SifLoadFileInit();
-        fileXioInit();
-	sbv_patch_disable_prefix_check();
-	SifLoadModule("rom0:SIO2MAN", 0, NULL);
-	SifLoadModule("rom0:MCMAN", 0, NULL);
-	SifLoadModule("rom0:MCSERV", 0, NULL);
-	SifLoadModule("rom0:PADMAN", 0, NULL);
-
-	setupPad();
-	waitAnyPadReady();
-}
-
-void LoadElf(char *filename, char *party)
-{
-
-	char *args[1];
-	t_ExecData exec;
-	SifLoadElf(filename, &exec);
-
-	if (exec.epc > 0)
-	{
-		ResetIOP();
-
-		if (party != 0)
-		{
-			args[0] = party;
-			ExecPS2((void *)exec.epc, (void *)exec.gp, 1, args);
-		}
-		else
-		{
-			ExecPS2((void *)exec.epc, (void *)exec.gp, 0, NULL);
-		}
-	}
-}
-
-int file_exists(char filepath[])
-{
-	int fdn;
-
-    fdn = fileXioOpen(filepath, O_RDONLY);
-    if (fdn < 0)
-        return 0;
-    fileXioClose(fdn);
-
-	return 1;
-}
-
 int main(int argc, char *argv[])
 {
+        u32 lastKey = 0;
+        int isEarlyJap = 0;
 
-	u32 lastKey = 0;
-	int isEarlyJap = 0;
+        wipeUserMem();
 
-	wipeUserMem();
+        InitPS2();
 
-	InitPS2();
+        SifLoadModule("rom0:PADMAN", 0, NULL);
+        setupPad();
+        waitAnyPadReady();
 
-	int fdnr;
-    if ((fdnr = fileXioOpen("rom0:ROMVER", O_RDONLY)) > 0)
-    { // Reading ROMVER
-            fileXioRead(fdnr, romver, sizeof romver);
-            fileXioClose(fdnr);
-    }
+        int fdnr;
+        if ((fdnr = fileXioOpen("rom0:ROMVER", O_RDONLY)) > 0)
+        { // Reading ROMVER
+                fileXioRead(fdnr, romver, sizeof romver);
+                fileXioClose(fdnr);
+        }
 
-	// Getting region char
-	romver_region_char[0] = (romver[4] == 'E' ? 'E' : (romver[4] == 'J' ? 'I' : (romver[4] == 'H' ? 'A' : (romver[4] == 'U' ? 'A' : romver[4]))));
+        // Getting region char
+        romver_region_char[0] = (romver[4] == 'E' ? 'E' : (romver[4] == 'J' ? 'I' : (romver[4] == 'H' ? 'A' : (romver[4] == 'U' ? 'A' : romver[4]))));
 
-	strncpy(ROMVersionNumStr, romver, 4);
-	ROMVersionNumStr[4] = '\0';
-	bios_version = strtoul(ROMVersionNumStr, NULL, 16);
+        strncpy(ROMVersionNumStr, romver, 4);
+        ROMVersionNumStr[4] = '\0';
+        bios_version = strtoul(ROMVersionNumStr, NULL, 16);
 
-	if ((romver_region_char[0] == 'J') && (bios_version <= 0x120))
-		isEarlyJap = 1;
+        if ((romver_region_char[0] == 'J') && (bios_version <= 0x120))
+                isEarlyJap = 1;
 
-	//Stores last key during DELAY msec
+        //Stores last key during DELAY msec
 
-	//Waits for pad
-	waitAnyPadReady();
-	//If key was detected
-	if (readPad() && new_pad)
-		lastKey = new_pad;
+        //Waits for pad
+        waitAnyPadReady();
+        //If key was detected
+        if (readPad() && new_pad)
+                lastKey = new_pad;
 
-	//Deinits pad
-	if (!isEarlyJap)
-	{
-		padPortClose(0, 0);
-		padPortClose(1, 0);
-		padEnd();
-	}
+        //Deinits pad
+        if (!isEarlyJap)
+        {
+                padPortClose(0, 0);
+                padPortClose(1, 0);
+                padEnd();
+        }
 
-	if (lastKey & PAD_CIRCLE)
-	{
-		if (file_exists("mc0:/APPS/ULE.ELF"))
-			LoadElf("mc0:/APPS/ULE.ELF", "mc0:/APPS/");
+        if (lastKey & PAD_CIRCLE)
+        {
+                if (file_exists("mc0:/APPS/ULE.ELF"))
+                        LoadElf("mc0:/APPS/ULE.ELF", "mc0:/APPS/");
 
-		if (file_exists("mc1:/APPS/ULE.ELF"))
-			LoadElf("mc1:/APPS/ULE.ELF", "mc1:/APPS/");
+                if (file_exists("mc1:/APPS/ULE.ELF"))
+                        LoadElf("mc1:/APPS/ULE.ELF", "mc1:/APPS/");
 
-		if (file_exists("mc0:/APPS/OPNPS2LD.ELF"))
-			LoadElf("mc0:/APPS/OPNPS2LD.ELF", "mc0:/APPS/");
+                if (file_exists("mc0:/APPS/OPNPS2LD.ELF"))
+                        LoadElf("mc0:/APPS/OPNPS2LD.ELF", "mc0:/APPS/");
 
-		if (file_exists("mc1:/APPS/OPNPS2LD.ELF"))
-			LoadElf("mc1:/APPS/OPNPS2LD.ELF", "mc0:/APPS/");
-	}
-	else
-	{
-		if (file_exists("mc0:/APPS/OPNPS2LD.ELF"))
-			LoadElf("mc0:/APPS/OPNPS2LD.ELF", "mc0:/APPS/");
+                if (file_exists("mc1:/APPS/OPNPS2LD.ELF"))
+                        LoadElf("mc1:/APPS/OPNPS2LD.ELF", "mc0:/APPS/");
+        }
+        else
+        {
+                if (file_exists("mc0:/APPS/OPNPS2LD.ELF"))
+                        LoadElf("mc0:/APPS/OPNPS2LD.ELF", "mc0:/APPS/");
 
-		if (file_exists("mc1:/APPS/OPNPS2LD.ELF"))
-			LoadElf("mc1:/APPS/OPNPS2LD.ELF", "mc0:/APPS/");
+                if (file_exists("mc1:/APPS/OPNPS2LD.ELF"))
+                        LoadElf("mc1:/APPS/OPNPS2LD.ELF", "mc0:/APPS/");
 
-		if (file_exists("mc0:/APPS/ULE.ELF"))
-			LoadElf("mc0:/APPS/ULE.ELF", "mc0:/APPS/");
+                if (file_exists("mc0:/APPS/ULE.ELF"))
+                        LoadElf("mc0:/APPS/ULE.ELF", "mc0:/APPS/");
 
-		if (file_exists("mc1:/APPS/ULE.ELF"))
-			LoadElf("mc1:/APPS/ULE.ELF", "mc1:/APPS/");
-	}
+                if (file_exists("mc1:/APPS/ULE.ELF"))
+                        LoadElf("mc1:/APPS/ULE.ELF", "mc1:/APPS/");
+        }
 
-	__asm__ __volatile__(
-		"	li $3, 0x04;"
-		"	syscall;"
-		"	nop;");
+        __asm__ __volatile__(
+                "       li $3, 0x04;"
+                "       syscall;"
+                "       nop;");
 
-	return 0;
+        return 0;
 }


### PR DESCRIPTION
## Summary
- factor out common PS2 loading utilities into new `common/loader` module
- update both launchers to include and link shared loader, removing duplicated logic
- keep pad initialization in keys launcher after calling shared `InitPS2`

## Testing
- `make -C launcher-boot` *(fails: No rule to make target '/samples/Makefile.eeglobal')*
- `make -C launcher-keys` *(fails: No rule to make target '/samples/Makefile.eeglobal')*

------
https://chatgpt.com/codex/tasks/task_e_68af618844ec8321ac4a5d51b501d7cc