### PR TITLE
Switch to stdint types for pad handling

### DIFF
--- a/launcher-keys/main.c
+++ b/launcher-keys/main.c
@@ -1,4 +1,4 @@
-#include <tamtypes.h>
+#include <stdint.h>
 #include <loadfile.h>
 #include <fileXio_rpc.h>
 #include <libpad.h>
@@ -7,22 +7,26 @@
 #include <fcntl.h>
 #include "../common/loader.h"
 
+int readPad(void);
+void waitAnyPadReady(void);
+int setupPad(void);
+
 #define NTSC 2
 #define PAL 3
 
 #define DELAY 0
 
 int VMode = NTSC;
-extern u32 new_pad;
+extern uint32_t new_pad;
 
 char romver_region_char[1];
 char ROMVersionNumStr[5];
-u8 romver[16];
-u32 bios_version = 0;
+uint8_t romver[16];
+uint32_t bios_version = 0;
 
 int main(int argc, char *argv[])
 {
-        u32 lastKey = 0;
+        uint32_t lastKey = 0;
         int isEarlyJap = 0;
 
         wipeUserMem();

--- a/launcher-keys/pad.c
+++ b/launcher-keys/pad.c
@@ -33,7 +33,8 @@
  ---------------------------------------------------------------------------
 */
 
-#include <tamtypes.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <kernel.h>
 #include <libpad.h>
 
@@ -44,7 +45,7 @@
 // For video Mode
 extern int VMode;
 
-u32 new_pad;
+uint32_t new_pad;
 
 int  readPad(void);
 void waitAnyPadReady(void);
@@ -54,11 +55,11 @@ int  setupPad(void);
 
 static char padBuf_t[2][256] __attribute__((aligned(64)));
 struct padButtonStatus buttons_t[2];
-u32 padtype_t[2];
-u32 paddata, paddata_t[2];
-u32 old_pad = 0, old_pad_t[2] = {0, 0};
-u32 new_pad_t[2];
-u32 joy_value = 0;
+uint32_t padtype_t[2];
+uint32_t paddata_t[2];
+uint32_t old_pad = 0, old_pad_t[2] = {0, 0};
+uint32_t new_pad_t[2];
+uint32_t joy_value = 0;
 static int test_joy = 0;
 
 #define PAD_R3_V0 0x010000
@@ -73,8 +74,8 @@ static int test_joy = 0;
 //----------------------------------------------------------------
 int readPad(void)
 {
-	static int n[2]={0,0}, nn[2]={0,0};
-	int port, state, ret[2];
+        static int n[2]={0,0}, nn[2]={0,0};
+        int port, state, ret[2] = {0, 0};
 
 	for(port=0; port<2; port++){
 		if((state=padGetState(port, 0))==PAD_STATE_STABLE


### PR DESCRIPTION
## Summary
- include `<stddef.h>` and `<stdint.h>` for pad handling and use `uint32_t` throughout
- expose pad function prototypes and adopt standard integer types in main launcher code

## Testing
- `gcc -Wall -D_EE -I../ps2sdk-repo/common/include -I../ps2sdk-repo/ee/kernel/include -I../ps2sdk-repo/ee/rpc/pad/include -c launcher-keys/pad.c -o /tmp/pad.o` *(fails: warnings from `tamtypes.h` due to host compiler)*
- `make EE_CFLAGS+=' -Wall' PS2SDK=../../ps2sdk-repo` *(fails: missing `/samples/Makefile.eeglobal`)*

------
https://chatgpt.com/codex/tasks/task_e_68af6299eed48321a29547aef11a2f42