### PR TITLE
Use ps2sdk loader for payload

### DIFF
--- a/exploit/Makefile
+++ b/exploit/Makefile
@@ -12,7 +12,8 @@ EE_BIN_RAW = payload.bin
 EE_BIN_STRIPPED = payload-stripped.elf
 EE_OBJS = main.o payload_elf.o
 EE_LDFLAGS += -nostartfiles -Wl,-Ttext -Wl,$(LOADADDR) -Wl,--gc-sections
-EE_CFLAGS += -Os
+EE_CFLAGS += -Os -DLOADADDR=$(LOADADDR)
+EE_LIBS += -lpadload -lloadfile -lsifrpc
 
 all: $(EE_BIN_RAW)
 

--- a/exploit/main.c
+++ b/exploit/main.c
@@ -1,97 +1,31 @@
 #include <kernel.h>
-
-
-// ELF-loading stuff
-#define ELF_MAGIC 0x464c457f
-#define ELF_PT_LOAD 1
+#include <sifrpc.h>
+#include <loadfile.h>
+#include <elf.h>
 
 extern u8 payload_elf[];
 extern int size_payload_elf;
 
-
-
-
-//------------------------------
-typedef struct
-{
-	u8 ident[16]; // struct definition for ELF object header
-	u16 type;
-	u16 machine;
-	u32 version;
-	u32 entry;
-	u32 phoff;
-	u32 shoff;
-	u32 flags;
-	u16 ehsize;
-	u16 phentsize;
-	u16 phnum;
-	u16 shentsize;
-	u16 shnum;
-	u16 shstrndx;
-} elf_header_t;
-//------------------------------
-typedef struct
-{
-	u32 type; // struct definition for ELF program section header
-	u32 offset;
-	void *vaddr;
-	u32 paddr;
-	u32 filesz;
-	u32 memsz;
-	u32 flags;
-	u32 align;
-} elf_pheader_t;
-
-
-
-
-
-
-
-
 inline void _start()
 {
-	u8 *boot_elf;
-	elf_header_t *eh;
-	elf_pheader_t *eph;
-	void *pdata;
-	int i;
-	char *argv[2];
-	argv[0] = "payload";
-	argv[1] = "payload";
-	
+        t_ExecData exec;
+        Elf32_Ehdr *eh;
 
-	
-	/* Pointer to embedded payload  */
-	boot_elf = (u8 *)payload_elf;
-	eh = (elf_header_t *)boot_elf;
-	if (_lw((u32)&eh->ident) != ELF_MAGIC)
-		asm volatile("break\n");
+        eh = (Elf32_Ehdr *)payload_elf;
+        if (eh->e_entry != LOADADDR)
+                asm volatile("break\n");
 
-	eph = (elf_pheader_t *)(boot_elf + eh->phoff);
+        SifInitRpc(0);
 
-	/* Scan through the ELF's program headers and copy them into RAM, then
-									zero out any non-loaded regions.  */
-	for (i = 0; i < eh->phnum; i++)
-	{
-		if (eph[i].type != ELF_PT_LOAD)
-			continue;
+        if (SifLoadElfBuffer(payload_elf, size_payload_elf, &exec) < 0)
+                asm volatile("break\n");
 
-		pdata = (void *)(boot_elf + eph[i].offset);
-		memcpy(eph[i].vaddr, pdata, eph[i].filesz);
+        if (exec.epc != LOADADDR)
+                asm volatile("break\n");
 
-		if (eph[i].memsz > eph[i].filesz)
-			memset(eph[i].vaddr + eph[i].filesz, 0,
-				   eph[i].memsz - eph[i].filesz);
-	}
+        FlushCache(0);
+        FlushCache(2);
 
-	/* Let's go.  */
-	FlushCache(0);
-	FlushCache(2);
-
-	ExecPS2((void *)eh->entry, NULL, 2, argv);
+        ExecPS2((void *)exec.epc, (void *)exec.gp, 0, NULL);
 }
-
-
-
 


### PR DESCRIPTION
## Summary
- Replace manual ELF parsing with `SifLoadElfBuffer` and `ExecPS2` to boot embedded payload
- Remove custom ELF structs in favor of ps2sdk's `<elf.h>`
- Link against ps2sdk libraries and export `LOADADDR` to the build

## Testing
- `make -C exploit clean` *(fails: `/samples/Makefile.eeglobal: No such file or directory`)*
- `make -C exploit` *(fails: `/samples/Makefile.eeglobal: No such file or directory`)*
- `readelf -h exploit/payload.elf` *(fails: `No such file`)*

------
https://chatgpt.com/codex/tasks/task_e_68af643c8aa48321923fdac9f6275f9f