### PR TITLE
Add PS2 build workflow and document CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
     container: ps2dev/ps2dev
     steps:
       - uses: actions/checkout@v4
+      - name: Install make
+        run: apt-get update && apt-get install -y make
       - name: Install ps2-packer
         run: |
           if ! command -v ps2-packer >/dev/null 2>&1; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: ps2dev/ps2dev
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ps2-packer
+        run: |
+          if ! command -v ps2-packer >/dev/null 2>&1; then
+            make -C ps2-packer
+            make -C ps2-packer install
+          fi
+      - name: Build exploit
+        run: make -C exploit
+      - name: Build launcher-boot
+        run: make -C launcher-boot
+      - name: Build launcher-keys
+        run: make -C launcher-keys
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: elf-artifacts
+          path: |
+            exploit/*.elf
+            launcher-boot/*.elf
+            launcher-keys/*.elf

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 ## Source code for OpenTuna exploit and payloads.
+
+### Continuous Integration
+This repository uses a GitHub Actions workflow defined in `.github/workflows/build.yml` to build the project inside the
+`ps2dev/ps2dev` Docker image.
+The workflow installs `ps2-packer` when needed, runs `make` in the `exploit`, `launcher-boot`, and `launcher-keys` directories, and uploads the resulting `.elf` binaries as artifacts for every push and pull request.


### PR DESCRIPTION
## Summary
- build exploit and launchers in ps2dev/ps2dev container and upload .elf artifacts
- document GitHub Actions workflow in README

## Testing
- `make -C exploit` *(fails: No rule to make target `/samples/Makefile.eeglobal`)*
- `make -C launcher-boot` *(fails: No rule to make target `/samples/Makefile.eeglobal`)*
- `make -C launcher-keys` *(fails: No rule to make target `/samples/Makefile.eeglobal`)*

------
https://chatgpt.com/codex/tasks/task_e_68af6549dff0832187b3d18fb5979496