### PR TITLE
Fix mc1 LoadElf paths in launcher-keys

### DIFF
--- a/launcher-keys/main.c
+++ b/launcher-keys/main.c
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
                         LoadElf("mc0:/APPS/OPNPS2LD.ELF", "mc0:/APPS/");
 
                 if (file_exists("mc1:/APPS/OPNPS2LD.ELF"))
-                        LoadElf("mc1:/APPS/OPNPS2LD.ELF", "mc0:/APPS/");
+                        LoadElf("mc1:/APPS/OPNPS2LD.ELF", "mc1:/APPS/");
         }
         else
         {
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
                         LoadElf("mc0:/APPS/OPNPS2LD.ELF", "mc0:/APPS/");
 
                 if (file_exists("mc1:/APPS/OPNPS2LD.ELF"))
-                        LoadElf("mc1:/APPS/OPNPS2LD.ELF", "mc0:/APPS/");
+                        LoadElf("mc1:/APPS/OPNPS2LD.ELF", "mc1:/APPS/");
 
                 if (file_exists("mc0:/APPS/ULE.ELF"))
                         LoadElf("mc0:/APPS/ULE.ELF", "mc0:/APPS/");


### PR DESCRIPTION
## Summary
- Correct memory card 1 `LoadElf` call paths in `launcher-keys`

## Testing
- `make -C launcher-keys` *(fails: /samples/Makefile.eeglobal: No such file or directory)*
- `make -C exploit` *(fails: /samples/Makefile.eeglobal: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68af7b0ee51083218f5825426a05fed3