### PR TITLE
ci: install build tools before build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ jobs:
     container: ps2dev/ps2dev:latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install build tools
+        run: apk add --no-cache build-base
       - name: Set GSKIT environment
         run: echo "GSKIT=$PS2DEV/gsKit" >> $GITHUB_ENV
       - name: Build ps2-packer

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ export PATH="$PATH:$PS2DEV/bin"
 Each component of the project has its own `Makefile`. Build them individually from the repository root:
 
 ```bash
+make -C ps2-packer ps2-packer   # builds the host-side packer once
 make -C launcher-boot
 make -C launcher-keys
 make -C exploit            # builds using PAYLOAD=launcher-keys by default
@@ -38,5 +39,5 @@ make -C exploit PAYLOAD=launcher-boot
 ### Continuous Integration
 This repository uses a GitHub Actions workflow defined in `.github/workflows/build.yml` to build the project inside the
 `ps2dev/ps2dev` Docker image.
-The workflow installs `ps2-packer` when needed, runs `make` in the `exploit`, `launcher-boot`, and `launcher-keys` directories, and uploads the resulting `.elf` binaries as artifacts for every push and pull request.
+The workflow installs the necessary host build tools, builds `ps2-packer`, runs `make` in the `exploit`, `launcher-boot`, and `launcher-keys` directories, and uploads the resulting `.elf` binaries as artifacts for every push and pull request.
 


### PR DESCRIPTION
## Summary
- build workflow installs required host tools
- document building ps2-packer and CI setup

## Testing
- `make -C ps2-packer ps2-packer`
- `make -C launcher-boot` *(fails: `/samples/Makefile.eeglobal: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68af562f0f7c83218c2c61105df4e4ff