### PR TITLE
Switch to POSIX file I/O for new PS2 SDK

### DIFF
--- a/common/loader.c
+++ b/common/loader.c
@@ -4,9 +4,9 @@
 #include <kernel.h>
 #include <sifrpc.h>
 #include <loadfile.h>
-#include <fileXio_rpc.h>
 #include <sbv_patches.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 void wipeUserMem(void)
 {
@@ -38,11 +38,11 @@ void InitPS2(void)
         ResetIOP();
         SifInitIopHeap();
         SifLoadFileInit();
-        fileXioInit();
         sbv_patch_disable_prefix_check();
         SifLoadModule("rom0:SIO2MAN", 0, NULL);
         SifLoadModule("rom0:MCMAN", 0, NULL);
         SifLoadModule("rom0:MCSERV", 0, NULL);
+        SifLoadModule("rom0:FILEXIO", 0, NULL);
 }
 
 void LoadElf(char *filename, char *party)
@@ -71,10 +71,10 @@ int file_exists(char filepath[])
 {
         int fdn;
 
-        fdn = fileXioOpen(filepath, O_RDONLY);
+        fdn = open(filepath, O_RDONLY);
         if (fdn < 0)
                 return 0;
-        fileXioClose(fdn);
+        close(fdn);
 
         return 1;
 }

--- a/launcher-boot/Makefile
+++ b/launcher-boot/Makefile
@@ -7,7 +7,7 @@ EE_BIN_STRIPPED = payload-stripped.elf
 EE_BIN_PACKED = payload-packed.elf
 EE_OBJS = main.o ../common/loader.o
 EE_LDFLAGS += -Wl,--gc-sections -Wl,-Ttext -Wl,$(LOADADDR) -Wl,--defsym -Wl,_stack_size=$(STACKSIZE) -Wl,--defsym -Wl,_stack=$(STACKADDR)
-EE_LIBS += -lpatches -lfileXio
+EE_LIBS += -lpatches
 EE_INCS += -I$(GSKIT)/include -I$(PS2SDK)/ports/include
 EE_CFLAGS += -Os
 

--- a/launcher-keys/Makefile
+++ b/launcher-keys/Makefile
@@ -7,7 +7,7 @@ EE_BIN_STRIPPED = payload-stripped.elf
 EE_BIN_PACKED = payload-packed.elf
 EE_OBJS = main.o pad.o ../common/loader.o
 EE_LDFLAGS += -Wl,--gc-sections -Wl,-Ttext -Wl,$(LOADADDR) -Wl,--defsym -Wl,_stack_size=$(STACKSIZE) -Wl,--defsym -Wl,_stack=$(STACKADDR)
-EE_LIBS += -lpatches -lpad -lfileXio
+EE_LIBS += -lpatches -lpad
 EE_INCS += -I$(GSKIT)/include -I$(PS2SDK)/ports/include
 EE_CFLAGS += -Os
 

--- a/launcher-keys/main.c
+++ b/launcher-keys/main.c
@@ -1,10 +1,10 @@
 #include <stdint.h>
 #include <loadfile.h>
-#include <fileXio_rpc.h>
 #include <libpad.h>
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include "../common/loader.h"
 
 int readPad(void);
@@ -38,10 +38,10 @@ int main(int argc, char *argv[])
         waitAnyPadReady();
 
         int fdnr;
-        if ((fdnr = fileXioOpen("rom0:ROMVER", O_RDONLY)) > 0)
+        if ((fdnr = open("rom0:ROMVER", O_RDONLY)) > 0)
         { // Reading ROMVER
-                fileXioRead(fdnr, romver, sizeof romver);
-                fileXioClose(fdnr);
+                read(fdnr, romver, sizeof romver);
+                close(fdnr);
         }
 
         // Getting region char


### PR DESCRIPTION
## Summary
- Replace deprecated fileXio usage with POSIX open/close and load FILEXIO module
- Drop fileXio library linkage in EE payload Makefiles
- Update key launcher to read ROM version via POSIX calls

## Testing
- `make -C ps2-packer ps2-packer`
- `make -C launcher-boot` *(fails: No rule to make target '/samples/Makefile.eeglobal')*
- `make -C launcher-keys` *(fails: No rule to make target '/samples/Makefile.eeglobal')*

------
https://chatgpt.com/codex/tasks/task_e_68af961afd4c832187aea719a9660643